### PR TITLE
Handle empty relations

### DIFF
--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -23,8 +23,7 @@ export default DS.RESTAdapter.extend({
 
     var schemaDef = {
       singular: singular,
-      plural: plural,
-      relations: {}
+      plural: plural
     };
 
     // else it's new, so update
@@ -38,6 +37,9 @@ export default DS.RESTAdapter.extend({
       }
       var relDef = {};
       relDef[rel.kind] = rel.type.typeKey;
+      if (!schemaDef.relations) {
+        schemaDef.relations = {};
+      }
       schemaDef.relations[rel.key] = relDef;
       self._init(rel.type);
     });


### PR DESCRIPTION
relational-pouch requires non empty relations objects, see https://github.com/nolanlawson/relational-pouch/blob/8955f2dab1b137fd30adae801fcd1e72b1742cfd/lib/index.js#L78-L80. This fix allows for records without any relations to other records.
