### PR TITLE
Indicate that findQuery isn't supported yet

### DIFF
--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -77,6 +77,12 @@ export default DS.RESTAdapter.extend({
     return this.db.rel.find(type.typeKey, ids);
   },
 
+  findQuery: function(/* store, type, query */) {
+    throw new Error(
+      "findQuery not yet supported by ember-pouch. " +
+      "See https://github.com/nolanlawson/ember-pouch/issues/7.");
+  },
+
   find: function (store, type, id) {
     this._init(type);
     return this.db.rel.find(type.typeKey, id).then(function (payload) {


### PR DESCRIPTION
Without this override, the adapter inherits RESTAdapter's behavior, which results in seemingly random XHRs when `store.find(type, query)` is used.

(Implements my suggestion from a comment in #7.)
