### PR TITLE
Cancel listening to changes during teardown

### DIFF
--- a/dist/amd/pouchdb-adapter.js
+++ b/dist/amd/pouchdb-adapter.js
@@ -53,7 +53,7 @@ define(
 
         this.db.setSchema(this._schema);
 
-        this.db.changes({
+        this.changes = this.db.changes({
           since: 'now',
           live: true
         }).on('change', function (change) {
@@ -67,6 +67,10 @@ define(
             store.unloadRecord(rec);
           }
         }.bind(this));
+      },
+
+      willDestroy: function() {
+        this.changes.cancel();
       },
 
       _recordToData: function (store, type, record) {

--- a/dist/cjs/pouchdb-adapter.js
+++ b/dist/cjs/pouchdb-adapter.js
@@ -50,7 +50,7 @@ exports["default"] = DS.RESTAdapter.extend({
 
     this.db.setSchema(this._schema);
 
-    this.db.changes({
+    this.changes = this.db.changes({
       since: 'now',
       live: true
     }).on('change', function (change) {
@@ -64,6 +64,10 @@ exports["default"] = DS.RESTAdapter.extend({
         store.unloadRecord(rec);
       }
     }.bind(this));
+  },
+
+  willDestroy: function() {
+    this.changes.cancel();
   },
 
   _recordToData: function (store, type, record) {

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -58,7 +58,7 @@ exports["default"] = DS.RESTAdapter.extend({
 
     this.db.setSchema(this._schema);
 
-    this.db.changes({
+    this.changes = this.db.changes({
       since: 'now',
       live: true
     }).on('change', function (change) {
@@ -72,6 +72,10 @@ exports["default"] = DS.RESTAdapter.extend({
         store.unloadRecord(rec);
       }
     }.bind(this));
+  },
+
+  willDestroy: function() {
+    this.changes.cancel();
   },
 
   _recordToData: function (store, type, record) {

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -63,7 +63,7 @@ define("ember-pouch/pouchdb-adapter",
 
         this.db.setSchema(this._schema);
 
-        this.db.changes({
+        this.changes = this.db.changes({
           since: 'now',
           live: true
         }).on('change', function (change) {
@@ -77,6 +77,10 @@ define("ember-pouch/pouchdb-adapter",
             store.unloadRecord(rec);
           }
         }.bind(this));
+      },
+
+      willDestroy: function() {
+        this.changes.cancel();
       },
 
       _recordToData: function (store, type, record) {

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -49,7 +49,7 @@ export default DS.RESTAdapter.extend({
 
     this.db.setSchema(this._schema);
 
-    this.db.changes({
+    this.changes = this.db.changes({
       since: 'now',
       live: true
     }).on('change', function (change) {
@@ -63,6 +63,10 @@ export default DS.RESTAdapter.extend({
         store.unloadRecord(rec);
       }
     }.bind(this));
+  },
+
+  willDestroy: function() {
+    this.changes.cancel();
   },
 
   _recordToData: function (store, type, record) {


### PR DESCRIPTION
While I was trying to clear up the EventEmitter memory leak warning (#25), I figured it would be prudent to explicitly stop listening for change events when the application is being destroyed, such as in testing.
