### PR TITLE
Cancel listening to changes during teardown

### DIFF
--- a/dist/amd/pouchdb-adapter.js
+++ b/dist/amd/pouchdb-adapter.js
@@ -10,7 +10,7 @@ define(
         this._super();
 
         // Update store on change events
-        this.db.changes({
+        this.changes = this.db.changes({
           since: 'now',
           live: true
         }).on('change', function (change) {
@@ -24,6 +24,12 @@ define(
             store.unloadRecord(rec);
           }
         }.bind(this));
+      },
+
+      willDestroy: function() {
+        if (this.changes) {
+          this.changes.cancel();
+        }
       },
 
       _init: function (type) {

--- a/dist/cjs/pouchdb-adapter.js
+++ b/dist/cjs/pouchdb-adapter.js
@@ -7,7 +7,7 @@ exports["default"] = DS.RESTAdapter.extend({
     this._super();
 
     // Update store on change events
-    this.db.changes({
+    this.changes = this.db.changes({
       since: 'now',
       live: true
     }).on('change', function (change) {
@@ -21,6 +21,12 @@ exports["default"] = DS.RESTAdapter.extend({
         store.unloadRecord(rec);
       }
     }.bind(this));
+  },
+
+  willDestroy: function() {
+    if (this.changes) {
+      this.changes.cancel();
+    }
   },
 
   _init: function (type) {

--- a/dist/globals/main.js
+++ b/dist/globals/main.js
@@ -15,7 +15,7 @@ exports["default"] = DS.RESTAdapter.extend({
     this._super();
 
     // Update store on change events
-    this.db.changes({
+    this.changes = this.db.changes({
       since: 'now',
       live: true
     }).on('change', function (change) {
@@ -29,6 +29,12 @@ exports["default"] = DS.RESTAdapter.extend({
         store.unloadRecord(rec);
       }
     }.bind(this));
+  },
+
+  willDestroy: function() {
+    if (this.changes) {
+      this.changes.cancel();
+    }
   },
 
   _init: function (type) {

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -20,7 +20,7 @@ define("ember-pouch/pouchdb-adapter",
         this._super();
 
         // Update store on change events
-        this.db.changes({
+        this.changes = this.db.changes({
           since: 'now',
           live: true
         }).on('change', function (change) {
@@ -34,6 +34,12 @@ define("ember-pouch/pouchdb-adapter",
             store.unloadRecord(rec);
           }
         }.bind(this));
+      },
+
+      willDestroy: function() {
+        if (this.changes) {
+          this.changes.cancel();
+        }
       },
 
       _init: function (type) {

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -6,7 +6,7 @@ export default DS.RESTAdapter.extend({
     this._super();
 
     // Update store on change events
-    this.db.changes({
+    this.changes = this.db.changes({
       since: 'now',
       live: true
     }).on('change', function (change) {
@@ -20,6 +20,12 @@ export default DS.RESTAdapter.extend({
         store.unloadRecord(rec);
       }
     }.bind(this));
+  },
+
+  willDestroy: function() {
+    if (this.changes) {
+      this.changes.cancel();
+    }
   },
 
   _init: function (type) {


### PR DESCRIPTION
This cleans up the change listener when the application is being destroyed. It removes the `EventEmitter` memory leak warning discussed in #25, whose appearance was dramatically reduced by #23, but still happens for me when running my whole acceptance test suite.
