### PR TITLE
use npm for ember-source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 
@@ -10,19 +10,18 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=ember-2.0-stack
-  - EMBER_TRY_SCENARIO=ember-2.1-stack
-  - EMBER_TRY_SCENARIO=ember-2.2-stack
-  - EMBER_TRY_SCENARIO=ember-2.3-stack
   - EMBER_TRY_SCENARIO=ember-2.4-stack
+  - EMBER_TRY_SCENARIO=ember-2.8-stack
+  - EMBER_TRY_SCENARIO=ember-2.10-stack
+  - EMBER_TRY_SCENARIO=ember-2.12-stack
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
+#  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
+#    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - npm config set spin false

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-pouch",
   "dependencies": {
-    "ember": "~2.8.0",
-    "ember-cli-shims": "0.1.1",
     "phantomjs-polyfill-object-assign": "chuckplantain/phantomjs-polyfill-object-assign"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,123 +2,97 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-2.0-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.0.1'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': '2.0.3',
-          'ember-data': '2.0.1',
-          'ember-cli-shims': '0.0.6'
-        }
-      }
-    },
-    {
-      name: 'ember-2.1-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.1.0'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': '2.1.2',
-          'ember-data': '2.1.0',
-          'ember-cli-shims': '0.0.6'
-        }
-      }
-    },
-    {
-      name: 'ember-2.2-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.2.1'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': '2.2.2',
-          'ember-data': '2.2.1',
-          'ember-cli-shims': '0.0.6'
-        }
-      }
-    },
-    {
-      name: 'ember-2.3-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.3.3'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': '2.3.2'
-        }
-      }
-    },
-    {
       name: 'ember-2.4-stack',
       npm: {
         devDependencies: {
-          'ember-data': '2.4.3'
+          'ember-data': '2.4.3',
+          'ember-inflector': '^1.9.4',
+          'ember-source': null,
+          'ember-cli-shims': null
         }
       },
       bower: {
         dependencies: {
-          'ember': '2.4.6'
+          'ember': '2.4.6',
+          "ember-cli-shims": "0.1.1"
         }
       }
+    },
+    {
+      name: 'ember-2.8-stack',
+      npm: {
+        devDependencies: {
+          'ember-data': '2.8.1',
+          'ember-inflector': '^1.9.4',
+          'ember-source': null,
+          'ember-cli-shims': null
+        }
+      },
+      bower: {
+        dependencies: {
+          'ember': '2.8.3',
+          "ember-cli-shims": "0.1.1"
+        }
+      }
+    },
+    {
+      name: 'ember-2.10-stack',
+      npm: {
+        devDependencies: {
+          'ember-data': '2.10.0',
+          'ember-inflector': '^1.9.4',
+          'ember-source': null,
+          'ember-cli-shims': null
+        }
+      },
+      bower: {
+        dependencies: {
+          'ember': '2.10.2',
+          "ember-cli-shims": "0.1.1"
+        }
+      }
+    },
+    {
+      name: 'ember-2.12-stack',
+      npm: {
+        devDependencies: {
+          'ember-data': '2.12.2',
+          'ember-inflector': '^1.9.4',
+          'ember-source': '2.12.2',
+          'ember-cli-shims': "^1.1.0"
+        }
+      },
     },
     {
       name: 'ember-release',
       npm: {
         devDependencies: {
-          'ember-data': 'components/ember-data#release'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
+          'ember-data': 'components/ember-data#release',
+          'ember-source': 'latest',
         },
-        resolutions: {
-          'ember': 'release'
-        }
-      }
+      },
     },
     {
       name: 'ember-beta',
       npm: {
         devDependencies: {
-          'ember-data': 'components/ember-data#beta'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
+          'ember-data': 'components/ember-data#beta',
+          'ember-source': 'beta',
         },
-        resolutions: {
-          'ember': 'beta'
-        }
-      }
+      },
     },
-    {
-      name: 'ember-canary',
-      npm: {
-        devDependencies: {
-          'ember-data': 'components/ember-data#canary'
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      }
-    }
+//    {
+//      name: 'ember-canary',
+//      npm: {
+//        devDependencies: {
+//          'ember-data': 'components/ember-data#canary',
+//          'ember-source': 'emberjs/ember.js#master',
+//          'ember-cli-htmlbars-inline-precompile': '^0.4.0',
+//        },
+//        dependencies: {
+//          'ember-cli-babel': '6.0.0',
+//		}
+//      },
+//    }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -32,33 +32,36 @@
     "url": "https://github.com/nolanlawson/ember-pouch/issues"
   },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-cli": "2.8.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^3.0.0",
+    "ember-cli": "2.13.1",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-qunit": "^3.0.0",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.8.0",
+    "ember-data": "2.12.2",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "^1.1.0",
-    "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.1"
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "2.12.2",
+    "loader.js": "^4.0.1",
+    "ember-inflector": "^1.9.4"
   },
   "dependencies": {
     "broccoli-stew": "^1.3.1",
     "pouchdb": "^6.1.2",
     "relational-pouch": "^1.4.5",
     "pouchdb-find": "^0.10.3",
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.2.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/adapters/pouch-basics-test.js
+++ b/tests/integration/adapters/pouch-basics-test.js
@@ -226,8 +226,12 @@ test('creating an associated record stores a reference to it in the parent', fun
 
   var done = assert.async();
   Ember.RSVP.Promise.resolve().then(() => {
+  	var s = { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor'} };
+  	if (savingHasMany()) {
+  		s.data.ingredients = [];
+  	}
     return this.db().bulkDocs([
-      { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor', ingredients: [] } }
+      s
     ]);
   }).then(() => {
     return this.store().findRecord('taco-soup', 'C');
@@ -236,8 +240,9 @@ test('creating an associated record stores a reference to it in the parent', fun
       name: 'pineapple',
       soup: tacoSoup
     });
-
-    return newIngredient.save().then(() => tacoSoup.save());
+	
+	//tacoSoup.save() actually not needed in !savingHasmany mode, but should still work
+    return newIngredient.save().then(() => savingHasMany() ? tacoSoup.save() : tacoSoup);
   }).then(() => {
   	this.store().unloadAll();
   	


### PR DESCRIPTION
This wont work for canary tests, but npm is the future and bower is going away. Also changed minimum ember version tested to 2.4