### PR TITLE
re-enable canary testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ env:
   - EMBER_TRY_SCENARIO=ember-2.12-stack
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
-#  - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
   allow_failures:
-#    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - npm config set spin false

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -68,7 +68,7 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-data': 'components/ember-data#release',
-          'ember-source': 'latest',
+          'ember-source': 'components/ember#release',
         },
       },
     },
@@ -77,22 +77,18 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-data': 'components/ember-data#beta',
-          'ember-source': 'beta',
+          'ember-source': 'components/ember#beta',
         },
       },
     },
-//    {
-//      name: 'ember-canary',
-//      npm: {
-//        devDependencies: {
-//          'ember-data': 'components/ember-data#canary',
-//          'ember-source': 'emberjs/ember.js#master',
-//          'ember-cli-htmlbars-inline-precompile': '^0.4.0',
-//        },
-//        dependencies: {
-//          'ember-cli-babel': '6.0.0',
-//		}
-//      },
-//    }
+    {
+      name: 'ember-canary',
+      npm: {
+        devDependencies: {
+          'ember-data': 'components/ember-data#canary',
+          'ember-source': 'components/ember#canary',
+        },
+      },
+    }
   ]
 };


### PR DESCRIPTION
We can still use the 'normal' components way, don't know why I thought this didn't work earlier. Could have sworn that it gave some errors...
But is working again now.