### PR TITLE
Fix some jobs on Travis Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 ---
 language: node_js
 node_js:
-  # we recommend testing addons with the same minimum supported node version as Ember CLI
-  # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   - bower --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
+  - which yarn
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - bower --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
-  - which yarn
+  - rm /usr/local/bin/yarn
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ before_install:
   - bower --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
-  - rm /usr/local/bin/yarn
+  - echo $PATH
+  - echo "echo fakeyarn" >> yarn
+  - export PATH=.:$PATH
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ before_install:
   - bower --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
-  - echo "echo fakeyarn" >> yarn
-  - chmod a+x yarn
-  - export PATH=.:$PATH
-  - echo $PATH
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-dist: precise
+dist: trusty
 language: node_js
 node_js:
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,33 @@
 ---
-dist: trusty
 language: node_js
 node_js:
-  - "6"
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "4"
 
 sudo: false
+dist: trusty
+
+addons:
+  chrome: stable
 
 cache:
   directories:
     - $HOME/.npm
 
 env:
-  - EMBER_TRY_SCENARIO=ember-2.4-stack
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-2.10-stack
-  - EMBER_TRY_SCENARIO=ember-lts-2.12
-  - EMBER_TRY_SCENARIO=ember-2.14-stack
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-#  - EMBER_TRY_SCENARIO=ember-canary
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+  matrix:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-2.8
+    - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
@@ -27,16 +36,10 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
-  - bower --version
-  - npm install -g phantomjs-prebuilt
-  - phantomjs --version
-
-install:
-  - npm install
-  - bower install
+  - npm install -g npm@4
+  - npm --version
 
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
   - bower --version
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
-  - echo $PATH
   - echo "echo fakeyarn" >> yarn
   - export PATH=.:$PATH
+  - echo $PATH
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
   - npm install -g phantomjs-prebuilt
   - phantomjs --version
   - echo "echo fakeyarn" >> yarn
+  - chmod a+x yarn
   - export PATH=.:$PATH
   - echo $PATH
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "ember-pouch",
-  "dependencies": {
-    "phantomjs-polyfill-object-assign": "chuckplantain/phantomjs-polyfill-object-assign"
-  }
-}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,53 +2,18 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-2.4-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.4.3',
-          'ember-inflector': '^1.9.4',
-          'ember-source': null,
-          'ember-cli-shims': null
-        }
-      },
-      bower: {
-        dependencies: {
-          'ember': '2.4.6',
-          "ember-cli-shims": "0.1.1"
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.8',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.8.1',
-          'ember-inflector': '^1.9.4',
-          'ember-source': null,
-          'ember-cli-shims': null
-        }
-      },
       bower: {
         dependencies: {
-          'ember': '2.8.3',
-          "ember-cli-shims": "0.1.1"
-        }
-      }
-    },
-    {
-      name: 'ember-2.10-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.10.0',
-          'ember-inflector': '^1.9.4',
-          'ember-source': null,
-          'ember-cli-shims': null
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
         }
       },
-      bower: {
-        dependencies: {
-          'ember': '2.10.2',
-          "ember-cli-shims": "0.1.1"
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -56,48 +21,63 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-data': '2.12.2',
-          'ember-inflector': '^1.9.4',
-          'ember-source': '2.12.2',
-          'ember-cli-shims': "^1.1.0"
+          'ember-source': '~2.12.0'
         }
-      },
-    },
-    {
-      name: 'ember-2.14-stack',
-      npm: {
-        devDependencies: {
-          'ember-data': '2.14.10',
-          'ember-source': '2.14.1',
-        }
-      },
+      }
     },
     {
       name: 'ember-release',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      },
       npm: {
         devDependencies: {
-          'ember-data': 'latest',
-          'ember-source': 'latest',
-        },
+          'ember-source': null
+        }
       }
     },
     {
       name: 'ember-beta',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#beta'
+        },
+        resolutions: {
+          'ember': 'beta'
+        }
+      },
       npm: {
         devDependencies: {
-          'ember-data': 'beta',
-          'ember-source': 'beta',
-        },
+          'ember-source': null
+        }
       }
     },
-//    {
-//      name: 'ember-canary',
-//      npm: {
-//        devDependencies: {
-//          'ember-data': 'components/ember-data#canary',
-//          'ember-source': 'components/ember#canary',
-//        },
-//      },
-//    }
+    {
+      name: 'ember-canary',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#canary'
+        },
+        resolutions: {
+          'ember': 'canary'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
+      }
+    }
   ]
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,9 +14,6 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
-  app.import('bower_components/phantomjs-polyfill-object-assign/object-assign-polyfill.js', {
-    type: 'test'
-  });
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "broccoli-stew": "^1.3.1",
     "pouchdb": "^6.3.4",
     "relational-pouch": "^2.1.0",
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.7.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.1",
-    "ember-try": "0.2.11",
     "loader.js": "^4.2.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,18 +34,17 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "~2.14.1",
+    "ember-cli": "~2.16.2",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-eslint": "^3.0.0",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.14.10",
     "ember-disable-prototype-extensions": "^1.1.2",
@@ -53,14 +52,14 @@
     "ember-inflector": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.14.1",
+    "ember-source": "~2.16.0",
     "loader.js": "^4.2.3"
   },
   "dependencies": {
     "broccoli-stew": "^1.3.1",
     "pouchdb": "^6.3.4",
     "relational-pouch": "^2.1.0",
-    "ember-cli-babel": "^6.3.0"
+    "ember-cli-babel": "^6.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "CouchDB"
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "author": "Nolan Lawson",
   "license": "Apache-2.0",
@@ -54,6 +54,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.1",
+    "ember-try": "0.2.11",
     "loader.js": "^4.2.3"
   },
   "dependencies": {
@@ -61,9 +62,6 @@
     "pouchdb": "^6.3.4",
     "relational-pouch": "^1.4.5",
     "ember-cli-babel": "^6.3.0"
-  },
-  "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/testem.js
+++ b/testem.js
@@ -3,10 +3,20 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'PhantomJS'
+    'Chrome'
   ],
   launch_in_dev: [
-    'PhantomJS',
     'Chrome'
-  ]
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
+  }
 };

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,8 +9,8 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -46,7 +46,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    // here you can enable a production-specific feature
   }
 
   return ENV;

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
 import { module } from 'qunit';
-import Ember from 'ember';
+import { resolve } from 'rsvp';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();


### PR DESCRIPTION
This is a pretty hackish solution to [this problem](https://github.com/ember-cli/ember-try/issues/125), also discussed [here](https://github.com/ember-cli/ember-try/issues/133): `ember-try` uses the presence of a `yarn` command to determine whether to `yarn install`. Something was [going wrong with the `yarn install`](https://travis-ci.org/pouchdb-community/ember-pouch/jobs/257985277#L3444-L3454) on the `ember-release` and `ember-beta` scenarios.

This fixes those scenarios but then breaks the ones before them, the inverse of what was happening!

I’m going to ask over on the `ember-try` thread about whether it’s possible to bypass Yarn more elegantly. I’ll also see if I can override Ember CLI’s built-in `ember-try` version with an older one that doesn’t use Yarn.