### PR TITLE
Bundle find

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,6 @@ module.exports = {
       files: ['pouchdb.relational-pouch.js']
     });
 
-    var pouchdbFind = stew.find(path.join(path.dirname(require.resolve('pouchdb-find')), '..', 'dist'), {
-      destDir: 'pouchdb',
-      files: ['pouchdb.find.js']
-    });
-
     var shims = stew.find(__dirname + '/vendor/pouchdb', {
       destDir: 'pouchdb',
       files: ['shims.js']
@@ -41,7 +36,6 @@ module.exports = {
     return stew.find([
       pouchdb,
       relationalPouch,
-      pouchdbFind,
       shims
     ]);
   },
@@ -49,7 +43,6 @@ module.exports = {
   included(app) {
     app.import('vendor/pouchdb/pouchdb.js');
     app.import('vendor/pouchdb/pouchdb.relational-pouch.js');
-    app.import('vendor/pouchdb/pouchdb.find.js');
     app.import('vendor/pouchdb/shims.js', {
       exports: { 'pouchdb': [ 'default' ]}
     });

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "broccoli-stew": "^1.3.1",
     "pouchdb": "^6.3.4",
-    "relational-pouch": "1.4.5",
+    "relational-pouch": "jlami/relational-pouch#bundle-find",
     "ember-cli-babel": "^6.3.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-pouch",
-  "version": "4.2.9",
+  "version": "4.3.0",
   "description": "PouchDB adapter for Ember Data",
   "directories": {
     "doc": "doc",
@@ -59,7 +59,7 @@
   "dependencies": {
     "broccoli-stew": "^1.3.1",
     "pouchdb": "^6.3.4",
-    "relational-pouch": "jlami/relational-pouch#bundle-find",
+    "relational-pouch": "^2.0.0",
     "ember-cli-babel": "^6.3.0"
   },
   "engines": {


### PR DESCRIPTION
Pouchdb-find is bundled in relational-pouch now.
Should be a non breaking change for this package.
Travis can only be run after relational-pouch 2.0.0 is published.