### PR TITLE
filter results of pouch adapter query by correct type

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -351,7 +351,15 @@ export default DS.RESTAdapter.extend({
       queryParams.sort = this._buildSort(query.sort);
     }
 
-    return db.find(queryParams).then(pouchRes => db.rel.parseRelDocs(recordTypeName, pouchRes.docs));
+    var idType = type.documentType || recordTypeName;
+    var recordTypeNameRegex = new RegExp('^' + idType + '_[0-3]');
+
+    return db.find(queryParams)
+      .then(function({ docs }) {
+        let matchinDocs = docs.filter(({ _id }) => _id.match(recordTypeNameRegex));
+        return { docs: matchinDocs };
+      })
+      .then(pouchRes => db.rel.parseRelDocs(recordTypeName, pouchRes.docs));
   },
 
   queryRecord: function(store, type, query) {


### PR DESCRIPTION
right now when using `query`, the ember-pouch adapter actually returns all document types from the pouchdb that match the selector...