### PR TITLE
Added test-waiter to fix sporadic error during testing

### DIFF
--- a/addon/operations-waiter.js
+++ b/addon/operations-waiter.js
@@ -1,0 +1,29 @@
+import Ember from "ember";
+
+class OperationsWaiter {
+  constructor() {
+    this._pendingOperations = 0;
+
+    if (Ember.testing) {
+      this._registerWaiter();
+    }
+  }
+
+  incrementPendingOps() {
+    this._pendingOperations++;
+  }
+
+  decrementPendingOps() {
+    this._pendingOperations--;
+  }
+
+  _shouldContinue() {
+    return this._pendingOperations === 0;
+  }
+
+  _registerWaiter() {
+    Ember.Test.registerWaiter(() => this._shouldContinue());
+  }
+}
+
+export { OperationsWaiter as default };


### PR DESCRIPTION
During my acceptance tests I had sporadic errors like the followings:

- `Error: Assertion Failed: You can only unload a record which is not inFlight`
- `Error: Called stop() outside of a test context at Object.extend.stop`

I've discovered these errors can happen when you try to create, modify and then delete a record. In detail this happens to me caouse in my acceptance tests I destroy the db in `beforeEach`.

Some attempts have been made to resolve this odd situation, like [ember-cli-test-model-waiter](https://github.com/gabrielgrant/ember-cli-test-model-waiter) but they're buggy and they often don't work.
Trying to fix this issue I've found a similar issue on [emberfire#312](https://github.com/firebase/emberfire/issues/312) then fixed in [#344](https://github.com/firebase/emberfire/pull/344).

This PR includes the emberfire fixes, resolving the above mentioned issues.

P.S. sadly I really don't know how to test this fix, cause the issues are sporadic and unpredictable