### PR TITLE
Add testing for LTS versions up to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
+    - EMBER_TRY_SCENARIO=ember-lts-3.4
+    - EMBER_TRY_SCENARIO=ember-lts-3.8
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -86,6 +86,24 @@ module.exports = function() {
       }
     },
     {
+      name: 'ember-lts-3.4',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.4.0',
+          'ember-data': '~3.4.0',
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.8',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.8.0',
+          'ember-data': '~3.8.0',
+        }
+      }
+    },
+    {
       name: 'ember-release',
       npm: {
         devDependencies: {


### PR DESCRIPTION
I’m looking into what version of Ember and/or Ember Data is when [this test started failing](https://travis-ci.org/pouchdb-community/ember-pouch/jobs/522967859#L4453-L4458). I figured we might as well be testing the more recent LTSs.

Based on this, it looks like the problem is somewhere after 3.4, up to and including 3.8. I’ll be looking into it more deeply and maybe I can come up with a PR, but it’s daunting.