### PR TITLE
Add logging that hints at relationship bug ≥ ED3.5

### DIFF
--- a/tests/integration/adapters/pouch-basics-test.js
+++ b/tests/integration/adapters/pouch-basics-test.js
@@ -266,6 +266,8 @@ test('create a new record', function (assert) {
 test('creating an associated record stores a reference to it in the parent', function (assert) {
   assert.expect(1);
 
+  var brokenTest = !config.emberPouch.saveHasMany && !config.emberPouch.async;
+
   var done = assert.async();
   Ember.RSVP.Promise.resolve().then(() => {
 		var s = { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor'} };
@@ -290,8 +292,15 @@ test('creating an associated record stores a reference to it in the parent', fun
 
     return this.store().findRecord('taco-soup', 'C');
   }).then(tacoSoup => {
+    if (brokenTest) {
+      console.log(JSON.stringify(tacoSoup._internalModel._recordData._relationships.get('ingredients').members.list.map(m => { return {id: m.id, clientId: m.clientId, data: m._data}; }), null, 2)); //eslint-disable-line
+    }
     return tacoSoup.get('ingredients');
   }).then(foundIngredients => {
+    if (brokenTest) {
+      console.log('found ingredients:', foundIngredients.map(i => `${i.id}: ${i.name}`)); //eslint-disable-line
+    }
+
     assert.deepEqual(foundIngredients.mapBy('name'), ['pineapple'],
       'should have fully loaded the associated items');
   }).finally(done);


### PR DESCRIPTION
This isn’t a change I think should actually be merged, but it helps reveal what’s causing [this test failure](https://travis-ci.org/pouchdb-community/ember-pouch/jobs/522967859#L4453-L4458) start with Ember Data 3.5.

I feel like I have insufficient knowledge of how the internals of RecordData etc work to understand what’s happening and fix it. But you can see from the `console.log` statements that there are two copies of the related model being stored; one seems maybe-deleted but still hanging around?

```
           [
              {
                "id": "29072F20-1883-0097-8660-51714430829F",
                "clientId": 2,
                "data": {}
              },
              {
                "id": "29072F20-1883-0097-8660-51714430829F",
                "data": {
                  "name": "pineapple",
                  "rev": "1-52f8d66785bec8cc48d5599314941d9e"
                }
              }
            ]
```

The actual `ingredients` returned later in the test have the same id:

```
            LOG: found ingredients: 29072F20-1883-0097-8660-51714430829F: pineapple,29072F20-1883-0097-8660-51714430829F: pineapple
```

This is only happening when `sync` is false and `saveHasMany` is false. I suppose there could be a hack that filters duplicate records out of a `hasMany` fetch but that seems less than desirable.