### PR TITLE
Update test matrix to include 2.18, 3.4, 3.8, and 3.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 sudo: required
 dist: trusty
@@ -24,6 +24,10 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
+    - EMBER_TRY_SCENARIO=ember-lts-3.4
+    - EMBER_TRY_SCENARIO=ember-lts-3.8
+    - EMBER_TRY_SCENARIO=ember-lts-3.12
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
@@ -36,8 +40,6 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - npm config set spin false
-  - npm install -g npm@4
   - npm --version
 
 script:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -85,6 +85,33 @@ module.exports = function() {
         }
       }
     },
+{
+      name: 'ember-lts-3.4',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.4.0',
+          'ember-data': '~3.4.0',
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.8',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.8.0',
+          'ember-data': '~3.8.0',
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.12',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.12.0',
+          'ember-data': '~3.12.0',
+        }
+      }
+    },
     {
       name: 'ember-release',
       npm: {

--- a/tests/integration/adapters/pouch-basics-test.js
+++ b/tests/integration/adapters/pouch-basics-test.js
@@ -286,8 +286,7 @@ test('creating an associated record stores a reference to it in the parent', fun
 	//tacoSoup.save() actually not needed in !savingHasmany mode, but should still work
     return newIngredient.save().then(() => savingHasMany() ? tacoSoup.save() : tacoSoup);
   }).then(() => {
-		this.store().unloadAll();
-
+    Ember.run(() => this.store().unloadAll());
     return this.store().findRecord('taco-soup', 'C');
   }).then(tacoSoup => {
     return tacoSoup.get('ingredients');
@@ -423,7 +422,7 @@ test('delete cascade null', function (assert) {
   .then((found) => {
     return found.destroyRecord();
   }).then(() => {
-    this.store().unloadAll();//to make sure the record is unloaded, normally this would be done by onChange listeren
+    Ember.run(() => this.store().unloadAll()); // normally this would be done by onChange listener
     return this.store().findRecord('food-item', 'Z');//Z should be updated now
   })
   .then((found) => {


### PR DESCRIPTION
Cherry-picked from #246 

Broadens test support matrix (Closes #242) and fixes test suite race condition with `store.unloadAll` that starts appearing in these newer versions (Closes #243).