### PR TITLE
Fix ember-try ember-data canary

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -134,7 +134,7 @@ module.exports = function() {
       name: 'ember-canary',
       npm: {
         devDependencies: {
-          'ember-data': 'emberjs/data#master',
+          'ember-data': 'canary',
           'ember-source': urls[2]
         }
       }


### PR DESCRIPTION
Needed since ember-data went mono-repo which requires build steps