### PR TITLE
Fix Adapter Blueprint for Ember Octane

### DIFF
--- a/blueprints/pouch-adapter/files/__root__/adapters/__name__.js
+++ b/blueprints/pouch-adapter/files/__root__/adapters/__name__.js
@@ -1,39 +1,8 @@
-import { Adapter } from 'ember-pouch';
+import config from '<%= dasherizedPackageName %>/config/environment';
 import PouchDB from 'ember-pouch/pouchdb';
-import config from '<%= dasherizedPackageName %>/config/environment';
-import Ember from 'ember';
-
-const { assert, isEmpty } = Ember;
-
-function createDb() {
-  let localDb = config.emberPouch.localDb;
-
-  assert('emberPouch.localDb must be set', !isEmpty(localDb));
-
-  let db = new PouchDB(localDb);
-
-  if (config.emberPouch.remoteDb) {
-    let remoteDb = new PouchDB(config.emberPouch.remoteDb);
-
-    db.sync(remoteDb, {
-      live: true,
-      retry: true
-    });
-  }
-
-  return db;
-}
-
-export default Adapter.extend({
-  init() {
-    this._super(...arguments);
-    this.set('db', createDb());
-  }
-});
-import config from '<%= dasherizedPackageName %>/config/environment';
-import PouchDB from 'pouchdb';
 import { Adapter } from 'ember-pouch';
 import { assert } from '@ember/debug';
+import { isEmpty } from '@ember/utils';
 
 export default class ApplicationAdapter extends Adapter {
 


### PR DESCRIPTION
Seems when ember-pouch was updated for Ember Octane the old blue print was not correctly removed. This PR should fix this.