### PR TITLE
Add support for fetching non-saved hasMany relationships

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -371,6 +371,8 @@ export default DS.RESTAdapter.extend({
     let inverse = record.type.inverseFor(rel.key, store);
     if (inverse && inverse.kind === 'belongsTo') {
       return this.get('db').rel.findHasMany(camelize(rel.type), inverse.name, record.id);
+    } else if (inverse && inverse.kind === 'hasMany') {
+      return this.db.rel.findHasMany(camelize(rel.type), inverse.name, { "$in": [record.id] });
     } else {
       let result = {};
       result[pluralize(rel.type)] = [];


### PR DESCRIPTION
When creating a ``hasMany`` - ``hasMany`` relationship it is possible to only save one side of the relation, to reduce the risk of merge conflict. 

However, the current implementation, only loads the `unsaved` side for a ``hasMany`` - ``belongsTo`` relationship, but not for a ``hasMany`` - ``hasMany`` relationship.

This change, allows to load the unsaved side in a ``hasMany`` - ``hasMany`` relationship, in a similar way ``hasMany`` - ``belongsTo`` does