### PR TITLE
Update README application adapter example to use JS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ db.sync(remote, {
 });
 
 export default class ApplicationAdapter extends Adapter {
-  db: db
+  db = db;
 }
 ```
 


### PR DESCRIPTION
I recently added this package to a new project and had some trouble getting the app to load and found the following error in the console: `Error: Please set the `db` property on the adapter.`. After changing the setup to use class properties instead it worked!